### PR TITLE
Dc 2.24 support

### DIFF
--- a/_admin.php
+++ b/_admin.php
@@ -30,29 +30,29 @@
 
 if (!defined('DC_CONTEXT_ADMIN')) {return;}
 
-l10n::set(dirname(__FILE__).'/locales/'.$_lang.'/admin');
+l10n::set(dirname(__FILE__).'/locales/'.dcCore::app()->lang.'/admin');
 
-$core->addBehavior('adminAfterCommentDesc',
+dcCore::app()->addBehavior('adminAfterCommentDesc',
 	array('AtReplyAdmin','adminAfterCommentDesc'));
 
 # from hum plugin
 # admin/comments.php Add actions on comments combo
-$core->addBehavior('adminCommentsActionsCombo',
+dcCore::app()->addBehavior('adminCommentsActionsCombo',
 	array('AtReplyAdmin','adminCommentsActionsCombo'));
 # admin/comments_actions.php Save actions on comments
-$core->addBehavior('adminCommentsActions',
+dcCore::app()->addBehavior('adminCommentsActionsV2',
 	array('AtReplyAdmin','adminCommentsActions'));
 # /from hum plugin
 
-$core->addBehavior('adminBeforeCommentCreate',
+dcCore::app()->addBehavior('adminBeforeCommentCreate',
 	array('AtReplyAdmin','adminBeforeCommentCreate'));
 
-$core->addBehavior('adminAfterCommentCreate',
+dcCore::app()->addBehavior('adminAfterCommentCreate',
 	array('AtReplyAdmin','adminAfterCommentCreate'));
 
-$_menu['Blog']->addItem(__('@ Reply'),'plugin.php?p=atReply',
+dcCore::app()->menu['Blog']->addItem(__('@ Reply'),'plugin.php?p=atReply',
 	'index.php?pf=atReply/icon.png',preg_match('/plugin.php\?p=atReply(&.*)?$/',
-		$_SERVER['REQUEST_URI']),$core->auth->check('admin',$core->blog->id));	
+		$_SERVER['REQUEST_URI']),dcCore::app()->auth->check('admin',dcCore::app()->blog->id));	
 
 class AtReplyAdmin
 {
@@ -83,14 +83,14 @@ class AtReplyAdmin
 	# from hum plugin
 	public static function adminCommentsActionsCombo($args)
 	{
-		if ($GLOBALS['core']->auth->check('publish,contentadmin',
-			$GLOBALS['core']->blog->id))
+		if (dcCore::app()->auth->check('publish,contentadmin',
+			dcCore::app()->blog->id))
 		{
 			$args[0][__('Create a new comment in reply to this comment')] = 'atreply_reply';
 		}
 	}
 
-	public static function adminCommentsActions($core,$co,$action,$redir)
+	public static function adminCommentsActions($action,$redir)
 	{
 		# ignore trackbacks
 		if ($co->comment_trackback == 1) {return;}
@@ -105,7 +105,7 @@ class AtReplyAdmin
 				
 				try
 				{
-					$rs = $core->blog->getPosts(
+					$rs = dcCore::app()->blog->getPosts(
 						array('post_id' => $post_id,
 							'post_type' => ''));
 					
@@ -113,12 +113,12 @@ class AtReplyAdmin
 						throw new Exception(__('Entry does not exist.'));
 					}
 					
-					$cur = $core->con->openCursor($core->prefix.'comment');
+					$cur = dcCore::app()->con->openCursor(dcCore::app()->prefix.'comment');
 					
-					$cur->comment_author = $core->auth->getInfo('user_cn');
-					$cur->comment_email = html::clean($core->auth->getInfo('user_email'));
-					$cur->comment_site = html::clean($core->auth->getInfo('user_url'));
-					$cur->comment_content = $core->HTMLfilter(
+					$cur->comment_author = dcCore::app()->auth->getInfo('user_cn');
+					$cur->comment_email = html::clean(dcCore::app()->auth->getInfo('user_email'));
+					$cur->comment_site = html::clean(dcCore::app()->auth->getInfo('user_url'));
+					$cur->comment_content = dcCore::app()->HTMLfilter(
 						'<p>'.
 							sprintf(__('@%s:'),'<a href="'.
 							$rs->getURL().'#c'.
@@ -132,15 +132,15 @@ class AtReplyAdmin
 					$cur->post_id = (integer) $post_id;
 					
 					# --BEHAVIOR-- adminBeforeCommentCreate
-					$core->callBehavior('adminBeforeCommentCreate',$cur);
+					dcCore::app()->callBehavior('adminBeforeCommentCreate',$cur);
 					
-					$comment_id = $core->blog->addComment($cur);
+					$comment_id = dcCore::app()->blog->addComment($cur);
 					
 					# --BEHAVIOR-- adminAfterCommentCreate
-					$core->callBehavior('adminAfterCommentCreate',$cur,$comment_id);
+					dcCore::app()->callBehavior('adminAfterCommentCreate',$cur,$comment_id);
 					
-					if (($core->blog->settings->atreply_subscribe_replied_comment == true)
-						&& ($core->plugins->moduleExists('subscribeToComments')))
+					if ((dcCore::app()->blog->settings->atreply_subscribe_replied_comment == true)
+						&& (dcCore::app()->plugins->moduleExists('subscribeToComments')))
 					{
 						# subscribe the email address of the replied comment
 						$subscriber = new subscriber($co->comment_email);
@@ -149,11 +149,11 @@ class AtReplyAdmin
 					
 					http::redirect('comment.php?id='.$comment_id.'&at_reply_creaco=1');
 				} catch (Exception $e) {
-					$core->error->add($e->getMessage());
+					dcCore::app()->error->add($e->getMessage());
 				}
 			}
 			
-			if (!$core->error->flag()) {
+			if (!dcCore::app()->error->flag()) {
 				http::redirect($redir);
 			}
 		}
@@ -161,9 +161,9 @@ class AtReplyAdmin
 	# /from hum plugin
 }
 
-$core->addBehavior('adminDashboardFavorites','atReplyDashboardFavorites');
+dcCore::app()->addBehavior('adminDashboardFavoritesV2','atReplyDashboardFavorites');
 
-function atReplyDashboardFavorites($core,$favs)
+function atReplyDashboardFavorites($favs)
 {
 	$favs->register('atReply', array(
 		'title' => __('@ Reply'),

--- a/_define.php
+++ b/_define.php
@@ -1,46 +1,39 @@
 <?php 
-# ***** BEGIN LICENSE BLOCK *****
-#
-# This file is part of @ Reply, a plugin for Dotclear 2
-# Copyright (C) 2008,2009,2010,2011 Moe (http://gniark.net/) and buns
-#
-# @ Reply is free software; you can redistribute it and/or
-# modify it under the terms of the GNU General Public License v2.0
-# as published by the Free Software Foundation.
-#
-# @ Reply is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public
-# License along with this program. If not, see
-# <http://www.gnu.org/licenses/>.
-#
-# Icon (icon.png) and images are from Silk Icons :
-# <http://www.famfamfam.com/lab/icons/silk/>
-#
-# Big icon (icon-big.png) come from Dropline Neu! :
-# <http://art.gnome.org/themes/icon?sort=popularity>
-#
-# Inspired by @ Reply for WordPress :
-# <http://iyus.info/at-reply-petit-plugin-wordpress-inspire-par-twitter/>
-#
-# ***** END LICENSE BLOCK *****
+/**
+ * @brief atReply, a plugin for Dotclear 2
+ *
+ * @package Dotclear
+ * @subpackage Plugin
+ *
+ * @author Moe, Pierre Van Glabeke and contributors
+ *
+ * @copyright GPL-2.0 https://www.gnu.org/licenses/gpl-2.0.html
+ *
+ * Icon (icon.png) and images are from Silk Icons :
+ * <http://www.famfamfam.com/lab/icons/silk/>
+ *
+ * Big icon (icon-big.png) come from Dropline Neu! :
+ * <http://art.gnome.org/themes/icon?sort=popularity>
+ *
+ * Inspired by atReply for WordPress :
+ * <http://iyus.info/at-reply-petit-plugin-wordpress-inspire-par-twitter/>
+ */
 
 if (!defined('DC_RC_PATH')) {return;}
 
 $this->registerModule(
-  /* Name */				'@ Reply',
-  /* Description*/	'Easily reply to comments',
-  /* Author */			'Moe (http://gniark.net/) append extension by buns.fr',
-  /* Version */			'1.8.3',
-	/* Properties */
-	array(
-		'permissions' => 'usage,contentadmin',
-		'type' => 'plugin',
-		'dc_min' => '2.6',
-		'support' => 'https://forum.dotclear.org/viewforum.php?id=16',
-		'details' => 'http://plugins.dotaddict.org/dc2/details/atReply'
-		)
+    'atReply',
+    'Easily reply to comments',
+    'Moe (http://gniark.net/) append extension by buns.fr, Pierre Van Glabeke and contributors',
+    '2.0-dev',
+    [
+        'requires'    => [['core', '2.24']],
+        'permissions' => dcCore::app()->auth->makePermissions([
+            dcAuth::PERMISSION_USAGE,
+            dcAuth::PERMISSION_CONTENT_ADMIN,
+        ]),
+        'type'       => 'plugin',
+        'support'    => 'http://forum.dotclear.org/viewtopic.php?id=16',
+        'details'    => 'https://plugins.dotaddict.org/dc2/details/' . basename(__DIR__),
+    ]
 );

--- a/_install.php
+++ b/_install.php
@@ -30,25 +30,16 @@
 
 if (!defined('DC_CONTEXT_ADMIN')) {return;}
 
-# On lit la version du plugin
-$m_version = $core->plugins->moduleInfo('atReply','version');
-
-# On lit la version du plugin dans la table des versions
-$i_version = $core->getVersion('atReply');
- 
 # La version dans la table est supérieure ou égale à
 # celle du module, on ne fait rien puisque celui-ci
 # est installé
-if (version_compare($i_version,$m_version,'>=')) {
-	return;
+if (!dcCore::app()->newVersion(basename(__DIR__), dcCore::app()->plugins->moduleInfo(basename(__DIR__), 'version'))) {
+    return;
 }
 
 # delete this setting which was saved in the wrong namespace
-$core->con->execute('DELETE FROM '.$core->prefix.'setting '.
+dcCore::app()->con->execute('DELETE FROM '.$core->prefix.'setting '.
 		'WHERE (setting_ns = \'atreply\') '.
 		'AND (setting_id = \'wiki_comments\');');
-
-# La procédure d'installation commence vraiment là
-$core->setVersion('atReply',$m_version);
 
 return true;

--- a/_public.php
+++ b/_public.php
@@ -30,23 +30,22 @@
 
 if (!defined('DC_RC_PATH')) {return;}
 
-$core->addBehavior('templateBeforeValue',array('AtReplyTpl','templateBeforeValue'));
-$core->addBehavior('templateAfterValue',array('AtReplyTpl','templateAfterValue'));
+dcCore::app()->addBehavior('templateBeforeValueV2',array('AtReplyTpl','templateBeforeValue'));
+dcCore::app()->addBehavior('templateAfterValueV2',array('AtReplyTpl','templateAfterValue'));
 
-$core->blog->settings->addNameSpace('atreply');
+dcCore::app()->blog->settings->addNameSpace('atreply');
 
-if ($core->blog->settings->atreply->atreply_active)
+if (dcCore::app()->blog->settings->atreply->atreply_active)
 {
-	$core->addBehavior('publicHeadContent',array('AtReplyTpl','publicHeadContent'));
-	$core->addBehavior('publicCommentBeforeContent',array('AtReplyTpl','publicCommentBeforeContent'));
+	dcCore::app()->addBehavior('publicHeadContent',array('AtReplyTpl','publicHeadContent'));
+	dcCore::app()->addBehavior('publicCommentBeforeContent',array('AtReplyTpl','publicCommentBeforeContent'));
 }
 
 class AtReplyTpl
 {
-	public static function templateBeforeValue($core,$v,$attr)
+	public static function templateBeforeValue($v,$attr)
 	{
-		global $core, $_ctx;
-		if ($v == 'CommentAuthorLink' && $_ctx->posts->commentsActive())
+		if ($v == 'CommentAuthorLink')
 		{
 			return('<span class="commentAuthor" '.
 				'id="atreply_<?php echo $_ctx->comments->comment_id; ?>" '.
@@ -54,7 +53,7 @@ class AtReplyTpl
 		}
 	}
 
-	public static function templateAfterValue($core,$v,$attr)
+	public static function templateAfterValue($v,$attr)
 	{
 		if ($v == 'CommentAuthorLink')
 		{
@@ -62,17 +61,17 @@ class AtReplyTpl
 		}
 	}
 	
-	public static function publicHeadContent($core)
+	public static function publicHeadContent()
 	{
-		$set = $core->blog->settings->atreply;
+		$set = dcCore::app()->blog->settings->atreply;
 		
-		$QmarkURL = $core->blog->getQmarkURL();
+		$QmarkURL = dcCore::app()->blog->getQmarkURL();
 		
 		# personalized image
 		if ((strlen($set->atreply_color) > 1)
-			&& (file_exists($core->blog->public_path.'/atReply/reply.png')))
+			&& (file_exists(dcCore::app()->blog->public_path.'/atReply/reply.png')))
 		{
-			$image_url = $core->blog->settings->system->public_url.
+			$image_url = dcCore::app()->blog->settings->system->public_url.
 				'/atReply/reply.png';
 		}
 		else
@@ -128,9 +127,9 @@ class AtReplyTpl
 			'pf=atReply/js/atReply.js'.'"></script>'."\n");
 	}
 	
-	public static function publicCommentBeforeContent($core,$ctx)
+	public static function publicCommentBeforeContent()
 	{
-			echo '<span id="atReplyComment'.$ctx->comments->f('comment_id').
+			echo '<span id="atReplyComment'.dcCore::app()->ctx->comments->f('comment_id').
 				'" style="display:none;"></span>';
 	}
 }

--- a/index.php
+++ b/index.php
@@ -30,7 +30,7 @@
 
 if (!defined('DC_CONTEXT_ADMIN')) {return;}
 
-if (!$core->auth->check('admin',$core->blog->id))
+if (!dcCore::app()->auth->check('admin',dcCore::app()->blog->id))
 {
 	echo('<html><head><title>Error</title></head>'.
 		'<body><p class="error">'.
@@ -41,9 +41,9 @@ if (!$core->auth->check('admin',$core->blog->id))
 
 $page_title = __('@ Reply');
 
-$core->blog->settings->addNameSpace('atreply');
+dcCore::app()->blog->settings->addNameSpace('atreply');
 
-$settings =& $core->blog->settings->atreply;
+$settings =& dcCore::app()->blog->settings->atreply;
 
 try
 {
@@ -58,7 +58,7 @@ try
 		if (!empty($_POST['atreply_active']))
 		{
 			# from commentsWikibar/index.php
-			$core->blog->settings->system->put('wiki_comments',true,'boolean');
+			dcCore::app()->blog->settings->system->put('wiki_comments',true,'boolean');
 		}
 		
 		$settings->put('atreply_display_title',!empty($_POST['atreply_display_title']),
@@ -86,7 +86,7 @@ try
 			$green = $color[1];
 			$blue = $color[2];	
 	
-			$dir = path::real($core->blog->public_path.'/atReply',false);
+			$dir = path::real(dcCore::app()->blog->public_path.'/atReply',false);
 			files::makeDir($dir,true);
 			$file_path = $dir.'/reply.png';
 	
@@ -136,18 +136,18 @@ try
 		# only update the blog if the setting have changed
 		if ($active == empty($_POST['atreply_active']))
 		{
-			$core->blog->triggerBlog();
+			dcCore::app()->blog->triggerBlog();
 			
 			# delete the cache directory
-			$core->emptyTemplatesCache();
+			dcCore::app()->emptyTemplatesCache();
 		}
 		
-		http::redirect($p_url.'&saveconfig=1');
+		http::redirect(dcCore::app()->admin->getPageURL().'&saveconfig=1');
 	}
 }
 catch (Exception $e)
 {
-	$core->error->add($e->getMessage());
+	dcCore::app()->error->add($e->getMessage());
 }
 
 if (isset($_GET['saveconfig']))
@@ -155,9 +155,9 @@ if (isset($_GET['saveconfig']))
 	$msg = __('Configuration successfully updated.');
 }
 
-$image_url = $core->blog->getQmarkURL().'pf=atReply/img/reply.png';
+$image_url = dcCore::app()->blog->getQmarkURL().'pf=atReply/img/reply.png';
 
-$system = $core->blog->settings->system;
+$system = dcCore::app()->blog->settings->system;
 
 # personalized image
 if (strlen($settings->atreply_color) > 1)
@@ -173,7 +173,7 @@ if (strlen($settings->atreply_color) > 1)
 		if (substr($system->public_url,0,1) == '/')
 		{
 			# public_path is located at the root of the website
-			$image_url = $core->blog->host.'/'.$personalized_image;
+			$image_url = dcCore::app()->blog->host.'/'.$personalized_image;
 		}
 		else if (substr($system->public_url,0,4) == 'http')
 		{
@@ -181,7 +181,7 @@ if (strlen($settings->atreply_color) > 1)
 		}
 		else
 		{
-			$image_url = $core->blog->url.$personalized_image;
+			$image_url = dcCore::app()->blog->url.$personalized_image;
 		}
 	}
 }
@@ -198,13 +198,13 @@ if (strlen($settings->atreply_color) > 1)
 	{
 		echo dcPage::breadcrumb(
 			array(
-				html::escapeHTML($core->blog->name) => '',
+				html::escapeHTML(dcCore::app()->blog->name) => '',
 				'<span class="page-title">'.$page_title.'</span>' => ''
 			));
 	}
 	else
 	{
-		echo('<h2>'.html::escapeHTML($core->blog->name).' &rsaquo; '.
+		echo('<h2>'.html::escapeHTML(dcCore::app()->blog->name).' &rsaquo; '.
 			$page_title.'</h2>');
 	}
 	?>
@@ -223,7 +223,7 @@ if (strlen($settings->atreply_color) > 1)
 		}
 	?>
 	
-	<form method="post" action="<?php echo $p_url; ?>">
+	<form method="post" action="<?php echo dcCore::app()->admin->getPageURL(); ?>">
 		<div class="fieldset"><h4><?php echo(__('Activation')); ?></h4>
     <p><?php echo(form::checkbox('atreply_active',1,
 			$settings->atreply_active)); ?>
@@ -294,7 +294,7 @@ if (strlen($settings->atreply_color) > 1)
 		<p class="info"><?php echo(__('Visitors may see the old image if their browser still use it.')); ?></p>
 		</div>
 		
-		<p><?php echo $core->formNonce(); ?></p>
+		<p><?php echo dcCore::app()->formNonce(); ?></p>
 		<p><input type="submit" name="saveconfig" value="<?php echo __('Save'); ?>" /></p>
 	</form>
 

--- a/js/atReplyThread.js
+++ b/js/atReplyThread.js
@@ -191,7 +191,7 @@ function setCommentInfos(id)
 			var a = dd.html().match(/@<a href="http(.+)#c(\d+)"/i);
 			if (a)
 			{
-				commentInfos_list['c'+id] = new commentInfos(id, 'c'+a[1]);
+				commentInfos_list['c'+id] = new commentInfos(id, 'c'+a[2]);
 				// add to replies_list
 				replies_list[id] = a[2];
 			}

--- a/js/atReplyThread.js
+++ b/js/atReplyThread.js
@@ -6,7 +6,7 @@ var ancestors_count = 0;
 var first_margin = 25; // indent of the first level reply (in pixel)
 
 $(document).ready(function () {
-	if (!$("#comments > dl > dt").length) {
+	if (!$("#comments > dl > dt").length && !$("#comments > ul > li").length) {
 		return; // no comments, bail out
 	}
 	if (atreply_show_switch) {setSwitchTag();}
@@ -23,7 +23,7 @@ function setSwitchTag()
     var switch_tag = document.createElement("p");
     switch_tag.className = "threading";
     $("#comments h3").before(switch_tag)
-    $("#comments > p").html(
+    $("#comments > p.threading").html(
         '<label id="atReplySwitch">'+atReply_switch_text+': <input type="checkbox" id="threading-switch" '+
 		((atreply_append)? 'checked' : '')+
 		'/></label>').find("input").click(toggleAtReplyDisplay);
@@ -113,7 +113,7 @@ function commentInfos(comment_id, replied)
 
 function appendReplies(b)
 {
-	var dl = $("#comments > dl");
+	var dl = $("#comments > dl").length ? $("#comments > dl") : $("#comments > ul");
 	dl.empty();
 	
 	for(var v in comments_list)
@@ -206,7 +206,8 @@ function setCommentInfos(id)
 
 function getCommentsChildren()
 {
-	$("#comments > dl").children().each(function(i)
+	var dl = $("#comments > dl").length ? $("#comments > dl") : $("#comments > ul");
+	dl.children().each(function(i)
 	{
 		// add to comments_list : this element, and the id if it is a comment
 		comments_list[i] = new Array(this, null);
@@ -225,6 +226,9 @@ function getCommentsChildren()
 		{
 			var id = $(this).attr('id').replace(/^c/,'');
 			setCommentInfos(id);
+			// add this comment to the replied comment's children
+			if(commentInfos_list['c'+id].isReply())
+				commentInfos_list[commentInfos_list['c'+id].replies_to].addChild(commentInfos_list['c'+id]);
 		}
 		else
 		{


### PR DESCRIPTION
This pull request adds support for Dotclear v2.24. It also fix a bug when registering parent of the comment with absolute URL (wrong index of captured expression in regex). And it adds support for themes based on dotty tplset.

NB: I've updated version in `_define.php` to version 2.0-dev but I haven't modified the `changelog`.